### PR TITLE
Fix https://github.com/arcadellama/plex-nowplaying/issues/10

### DIFF
--- a/nowplaying
+++ b/nowplaying
@@ -70,7 +70,7 @@ blue="\033[34m"
 magenta="\033[35m"
 cyan="\033[36m"
 white="\033[37m"
- 
+
 ## Text Effect Definitions
 bold="\033[1m"
 italic="\033[3m"
@@ -93,7 +93,7 @@ get_conf() {
     ## Global configuration options
     NP_PLEX_HOST="${NP_PLEX_HOST:-}"
     NP_PLEX_PORT="${NP_PLEX_PORT:-}"
-    NP_PLEX_TOKEN="${NP_PLEX_TOKEN:-}" 
+    NP_PLEX_TOKEN="${NP_PLEX_TOKEN:-}"
     NP_PLEX_MAX_WIDTH="${NP_PLEX_MAX_WIDTH:-}"
     NP_PLEX_COLOR_MODE="${NP_PLEX_COLOR_MODE:-}"
 
@@ -191,7 +191,7 @@ dependency_check() {
         return 0
         fi
     done
-    
+
     log_error "curl, wget, fetch, or nc not found."
     exit 1
 }
@@ -294,11 +294,11 @@ download_xml() {
             ;;
          *wget)
             "$dl_agent" -T "$timeout" -qO - "$__url"
-            return "$?" 
+            return "$?"
             ;;
          *fetch)
             "$dl_agent" -T "$timeout" -qO - "$__url"
-            return "$?" 
+            return "$?"
             ;;
           *nc)
             printf "GET %s HTTP/1.0\r\n\r\n" "$__path" | \
@@ -349,10 +349,10 @@ print_nowplaying() {
 
     # Set column width
     if [ "$(command -v tput)" ]; then
-	__columns="$("$(command -v tput)" cols)"
+    __columns="$("$(command -v tput)" cols)"
         if [ "$max_width" -ne 0 ] && [ "$__columns" -gt "$max_width" ]; then
-	        __columns="$max_width"
-	    fi
+            __columns="$max_width"
+        fi
     else
         if [ "$max_width" -ne 0 ]; then
             __columns="$max_width"
@@ -372,7 +372,7 @@ print_nowplaying() {
 
     case "$__type" in
         episode)
-              # TV Episodes 
+              # TV Episodes
               __title="${__album}: ${__track}"
 
               # If it doesn't fit, spread over two lines
@@ -389,7 +389,7 @@ print_nowplaying() {
                   __album="${__album}:"
 
                 __output="$(printf "%${__col1}s %-${__col2}s%${__col3}s\n" \
-                      "$__number." "$__album" "";  
+                      "$__number." "$__album" "";
                       printf "%${__col1}s %-${__col2}s%${__col3}s\n" \
                       "" "$__track $(print_delim ${#__track} ${__col2})" \
                       "$__user $__transcode")"
@@ -422,7 +422,7 @@ print_nowplaying() {
                   __track="$(truncate_string "$__track" "$__col2")"
                   fi
 
-		          __album="${__album}:"
+                  __album="${__album}:"
 
                # 2 lines
                 __output="$(printf "%${__col1}s %-${__col2}s%${__col3}s\n" \
@@ -604,7 +604,7 @@ Example: 'nowplaying -p 192.168.1.1 -w 80 -t <PLEX_AUTH_TOKEN>'
 
   --netcat,--nc <path>   Force netcat (nc) as downloader.
                          (Path is optional.)
- 
+
          --verbose, -V   Print every error message.
 
                 --file   Point to a XML file for debugging
@@ -625,7 +625,7 @@ main() {
     check_conf
 
     while [ "$#" -gt 0 ]; do
-        case "$1" in 
+        case "$1" in
        --config|-c)
                 if [ ! -r "$2" ]; then
                     log_error "$2 config file not found."
@@ -649,13 +649,13 @@ main() {
                 max_width="$2"
                 shift 2 ;;
         --delim|-d)
-		        printf "[%s]: --delim, -d is deprecated\n" "$prgnam"
+                printf "[%s]: --delim, -d is deprecated\n" "$prgnam"
                 dot_leader="$2"
                 shift 2 ;;
            --color)
                 case "$2" in
                     on|off|auto|true|false|yes|no)
-                        color="$2" 
+                        color="$2"
                         shift 2 ;;
                     *)
                         color="on"
@@ -665,7 +665,7 @@ main() {
                 plex_file="$2"
                 shift 2 ;;
         --force|-f)
-		        printf "[%s]: --force is deprecated\n" "$prgnam"
+                printf "[%s]: --force is deprecated\n" "$prgnam"
                 skip_checks=1
                 shift 1 ;;
             --curl)
@@ -673,7 +673,7 @@ main() {
                     *curl)
                         if [ -x "$2" ]; then
                             dl_agent="$2"
-                            shift 2 
+                            shift 2
                         else
                             printf "[%s]: Error. Cannot find %s.\n" \
                                 "$prgnam" "$2"
@@ -682,7 +682,7 @@ main() {
                         ;;
                         *)
                         dl_agent="$(command -v curl)"
-                        shift 1 
+                        shift 1
                 esac
                 skip_checks=1 ;;
 
@@ -691,7 +691,7 @@ main() {
                     *wget)
                         if [ -x "$2" ]; then
                             dl_agent="$2"
-                            shift 2 
+                            shift 2
                         else
                             printf "[%s]: Error. Cannot find %s.\n" \
                                 "$prgnam" "$2"
@@ -707,7 +707,7 @@ main() {
                     *fetch)
                         if [ -x "$2" ]; then
                             dl_agent="$2"
-                            shift 2 
+                            shift 2
                         else
                             printf "[%s]: Error. Cannot find %s.\n" \
                                 "$prgnam" "$2"
@@ -724,7 +724,7 @@ main() {
                     *nc)
                         if [ -x "$2" ]; then
                             dl_agent="$2"
-                            shift 2 
+                            shift 2
                         else
                             printf "[%s]: Error. Cannot find %s.\n" \
                                 "$prgnam" "$2"

--- a/nowplaying
+++ b/nowplaying
@@ -121,8 +121,8 @@ color_check() {
        false|off|no)
             return 1 ;;
                   *)
-            if [ -x "$(command -v tput)" ]; then
-                if [ "$(tput colors)" ]; then
+            if [ -n "$TERM" ] && [ -x "$(command -v tput)" ]; then
+                if [ "$(TERM="$TERM" tput colors)" ]; then  # TERM might not be exported so we define it
                     return 0
                 fi
             fi
@@ -348,8 +348,8 @@ print_nowplaying() {
     __columns=""
 
     # Set column width
-    if [ "$(command -v tput)" ]; then
-    __columns="$("$(command -v tput)" cols)"
+    if [ -n "$TERM" ] && [ "$(command -v tput)" ]; then
+    __columns="$(TERM="$TERM" "$(command -v tput)" cols)"  # TERM might not be exported so we define it
         if [ "$max_width" -ne 0 ] && [ "$__columns" -gt "$max_width" ]; then
             __columns="$max_width"
         fi


### PR DESCRIPTION
This is at least a partial fix of https://github.com/arcadellama/plex-nowplaying/issues/10

This PR has two commits, the first just cleans up some whitespace. The second checks `$TERM` before invoking `tput` (which it forward the value of `$TERM` to explicitly in case `sh` has `TERM` as a variable but not in the environment).
